### PR TITLE
imp: extended account module with missing api endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ ark_elixir-*.tar
 
 # Ignore package lock file
 mix.lock
+
+# Ignore OSX .DS_Store
+.DS_Store 

--- a/lib/ark_client/api/one/account.ex
+++ b/lib/ark_client/api/one/account.ex
@@ -98,4 +98,59 @@ defmodule ArkEcosystem.Client.API.One.Account do
   def publickey(client, address) do
     client |> get("accounts/getPublickey", query: [address: address])
   end
+
+  @doc """
+  Get the total amount of accounts.
+
+  ## Examples
+
+      iex> ArkEcosystem.Client.API.One.Account.count(client) 
+      {:ok,
+        %{
+          "count" => 841,
+          "success" => true
+        }}
+  """
+  @spec count(Tesla.Client.t()) :: ArkEcosystem.Client.response()
+  def count(client) do
+    client |> get("accounts/count")
+  end
+
+  @doc """
+  Get all accounts
+
+  ## Examples
+
+      iex> ArkEcosystem.Client.API.One.Account.all(client) 
+      // TODO
+  """
+  @spec all(Tesla.Client.t()) :: ArkEcosystem.Client.response()
+  def all(client) do
+    client |> get("accounts/getAllAccounts")
+  end
+
+  @doc """
+  Get the top accounts
+
+  ## Examples
+
+      iex> ArkEcosystem.Client.API.One.Account.top(client) 
+      {:ok,
+       %{
+         "accounts" => [
+           %{
+             "address" => "DGihocTkwDygiFvmg6aG8jThYTic47GzU9",
+             "balance" => "11499593562120633",
+             "publicKey" => "024c8247388a02ecd1de2a3e3fd5b7c61ecc2797fa3776599d558333ef1802d231"
+           },
+           ...
+          ],
+         "success" => true
+       }}
+  """
+  @spec top(Tesla.Client.t()) :: ArkEcosystem.Client.response()
+  def top(client) do
+    client |> get("accounts/top")
+  end
+
 end


### PR DESCRIPTION
## Proposed changes

Added `getAllAccounts`, `top`, and `count` endpoints to the account module. 

I wanted to add some basic tests for them too, but it seems that [getAllAccounts](https://dexplorer.ark.io:8443/api/accounts/getAllAccounts) and [count](https://dexplorer.ark.io:8443/api/accounts/count) aren't working properly on devnet currently, so I'll await some feedback on that first.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)