### PR TITLE
test: remove warnings about quoted keywords

### DIFF
--- a/test/arkecosystem/client/one/accounts_test.exs
+++ b/test/arkecosystem/client/one/accounts_test.exs
@@ -18,15 +18,15 @@ defmodule ArkEcosystem.Client.API.One.AccountsTest do
       %{method: :get, url: "http://127.0.0.1:8443/api/accounts/delegates/fee"} ->
         json(%{"success" => true, "fee" => 2500000000})
       %{method: :get, url: "http://127.0.0.1:8443/api/accounts/delegates", query: [address: "dummy"]} ->
-        json(%{"success" => true, "delegates" => [%{"username" => "dummy"}]})
+        json(%{"success" => true, "delegates" => [%{username: "dummy"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/accounts", query: [address: "dummy"]} ->
-        json(%{"success" => true, "account" => %{"address" => "dummy"}})
+        json(%{"success" => true, "account" => %{address: "dummy"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/accounts/count"} ->
         json(%{"success" => true, "count" => 42})
       %{method: :get, url: "http://127.0.0.1:8443/api/accounts/getAllAccounts"} ->
-        json(%{"success" => true, "accounts" => [%{"address" => "dummy"}]})
+        json(%{"success" => true, "accounts" => [%{address: "dummy"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/accounts/top"} ->
-        json(%{"success" => true, "wallets" => [%{"address" => "dummy"}]})
+        json(%{"success" => true, "wallets" => [%{address: "dummy"}]})
     end
     :ok
   end

--- a/test/arkecosystem/client/one/blocks_test.exs
+++ b/test/arkecosystem/client/one/blocks_test.exs
@@ -14,9 +14,9 @@ defmodule ArkEcosystem.Client.One.BlocksTest do
       #%{method: :get, url: "http://127.0.0.1:8443/api/blocks/get", query: [id: "dummy"]} ->
       #  json(%{"success" => true, "block" => %{"id" = "dummy"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks"} ->
-        json(%{"success" => true, "blocks" => [%{"id" => "dummy"}]})
+        json(%{"success" => true, "blocks" => [%{id: "dummy"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/get"} ->
-        json(%{"success" => true, "block" => %{"id" => "dummy"}})
+        json(%{"success" => true, "block" => %{id: "dummy"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getEpoch"} ->
         json(%{"success" => true, "epoch" => "dummy::TimeZ"})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getHeight"} ->
@@ -26,7 +26,7 @@ defmodule ArkEcosystem.Client.One.BlocksTest do
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getFee"} ->
         json(%{"success" => true, "fee" => "dummyFee"})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getFees"} ->
-        json(%{"success" => true, "fees" => %{"send": "dummyFee"}})
+        json(%{"success" => true, "fees" => %{send: "dummyFee"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getMilestone"} ->
         json(%{"success" => true, "milestone" => 1})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getReward"} ->
@@ -34,7 +34,7 @@ defmodule ArkEcosystem.Client.One.BlocksTest do
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getSupply"} ->
         json(%{"success" => true, "supply" => 42})
       %{method: :get, url: "http://127.0.0.1:8443/api/blocks/getStatus"} ->
-        json(%{"success" => true, "epoch" => "dummy::TimeZ", "supply": 42})
+        json(%{"success" => true, "epoch" => "dummy::TimeZ", supply: 42})
     end
     :ok
   end

--- a/test/arkecosystem/client/one/delegates_test.exs
+++ b/test/arkecosystem/client/one/delegates_test.exs
@@ -14,13 +14,13 @@ defmodule ArkEcosystem.Client.One.DelegatesTest do
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates/count"} ->
         json(%{"success" => true, "count" => 42})
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates/search", query: [q: "bold", limit: 2]} ->
-        json(%{"success" => true, "delegates" => [%{"username" => "boldninja"}]})
+        json(%{"success" => true, "delegates" => [%{username: "boldninja"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates/voters", query: [publicKey: "dummy"]} ->
-        json(%{"success" => true, "accounts" => [%{"address": "dummy"}]})
+        json(%{"success" => true, "accounts" => [%{address: "dummy"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates/get", query: [publicKey: "dummy"]} ->
-        json(%{"success" => true, "delegate" => %{"username" => "dummy"}})
+        json(%{"success" => true, "delegate" => %{username: "dummy"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates"} ->
-        json(%{"success" => true, "delegates" => [%{"username" => "dummy"}]})
+        json(%{"success" => true, "delegates" => [%{username: "dummy"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates/fee"} ->
         json(%{"success" => true, "fee" => 2500000000})
       %{method: :get, url: "http://127.0.0.1:8443/api/delegates/forging/getForgedByAccount", query: [generatorPublicKey: "dummy"]} ->

--- a/test/arkecosystem/client/one/loader_test.exs
+++ b/test/arkecosystem/client/one/loader_test.exs
@@ -16,7 +16,7 @@ defmodule ArkEcosystem.Client.API.One.LoaderTest do
       %{method: :get, url: "http://127.0.0.1:8443/api/loader/status/sync"} ->
         json(%{"success" => true, "syncing" => true})
       %{method: :get, url: "http://127.0.0.1:8443/api/loader/autoconfigure"} ->
-        json(%{"success" => true, "network" => %{"token": "dummy"}})
+        json(%{"success" => true, "network" => %{token: "dummy"}})
     end
     :ok
   end

--- a/test/arkecosystem/client/one/peers_test.exs
+++ b/test/arkecosystem/client/one/peers_test.exs
@@ -12,9 +12,9 @@ defmodule ArkEcosystem.Client.API.One.PeersTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:8443/api/peers/get", query: [ip: "0.0.0.0", port: 0]} ->
-        json(%{"success" => true, "peer" => %{"ip" => "0.0.0.0"}})
+        json(%{"success" => true, "peer" => %{ip: "0.0.0.0"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/peers"} ->
-        json(%{"success" => true, "peers" => [%{"ip" => "0.0.0.0"}]})
+        json(%{"success" => true, "peers" => [%{ip: "0.0.0.0"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/peers/version"} ->
         json(%{"success" => true, "version" => "1"})
     end

--- a/test/arkecosystem/client/one/transactions_test.exs
+++ b/test/arkecosystem/client/one/transactions_test.exs
@@ -12,13 +12,13 @@ defmodule ArkEcosystem.Client.API.One.TransactionsTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:8443/api/transactions/get", query: [id: "dummy"]} ->
-        json(%{"success" => true, "transaction" => %{"id" => "dummy"}})
+        json(%{"success" => true, "transaction" => %{id: "dummy"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/transactions"} ->
-        json(%{"success" => true, "transactions" => [%{"id" => "dummy"}]})
+        json(%{"success" => true, "transactions" => [%{id: "dummy"}]})
       %{method: :get, url: "http://127.0.0.1:8443/api/transactions/unconfirmed/get", query: [id: "dummy"]} ->
-        json(%{"success" => true, "transaction" => %{"id" => "dummy"}})
+        json(%{"success" => true, "transaction" => %{id: "dummy"}})
       %{method: :get, url: "http://127.0.0.1:8443/api/transactions/unconfirmed"} ->
-        json(%{"success" => true, "transactions" => [%{"id" => "dummy"}]})
+        json(%{"success" => true, "transactions" => [%{id: "dummy"}]})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/blocks_test.exs
+++ b/test/arkecosystem/client/two/blocks_test.exs
@@ -12,13 +12,13 @@ defmodule ArkEcosystem.Client.API.Two.BlocksTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/blocks/dummyId"} ->
-        json(%{"success" => true, "data" => %{ "id": "dummyId" }})
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/blocks"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/blocks/dummyId/transactions"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyTransactionId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyTransactionId" }]})
       %{method: :post, url: "http://127.0.0.1:4003/api/blocks/search"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummySearch" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/delegates_test.exs
+++ b/test/arkecosystem/client/two/delegates_test.exs
@@ -12,13 +12,13 @@ defmodule ArkEcosystem.Client.API.Two.DelegatesTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/delegates/dummyId"} ->
-        json(%{"success" => true, "data" => %{ "id": "dummyId" }})
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/delegates"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/delegates/dummyId/blocks"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyBlockId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyBlockId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/delegates/dummyId/voters"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyVoter" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyVoter" }]})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/node_test.exs
+++ b/test/arkecosystem/client/two/node_test.exs
@@ -12,11 +12,11 @@ defmodule ArkEcosystem.Client.API.Two.NodeTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/node/status"} ->
-        json(%{"success" => true, "data" => %{ "synced": true }})
+        json(%{"success" => true, "data" => %{ synced: true }})
       %{method: :get, url: "http://127.0.0.1:4003/api/node/syncing"} ->
-        json(%{"success" => true, "data" => %{ "syncing": true }})
+        json(%{"success" => true, "data" => %{ syncing: true }})
       %{method: :get, url: "http://127.0.0.1:4003/api/node/configuration"} ->
-        json(%{"success" => true, "data" => %{ "nethash": "dummyHash" }})
+        json(%{"success" => true, "data" => %{ nethash: "dummyHash" }})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/peers_test.exs
+++ b/test/arkecosystem/client/two/peers_test.exs
@@ -12,9 +12,9 @@ defmodule ArkEcosystem.Client.API.Two.PeersTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/peers/0.0.0.0"} ->
-        json(%{"success" => true, "data" => %{ "ip": "0.0.0.0" }})
+        json(%{"success" => true, "data" => %{ ip: "0.0.0.0" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/peers"} ->
-        json(%{"success" => true, "data" => [%{ "ip": "0.0.0.0" }]})
+        json(%{"success" => true, "data" => [%{ ip: "0.0.0.0" }]})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/transactions_test.exs
+++ b/test/arkecosystem/client/two/transactions_test.exs
@@ -12,19 +12,19 @@ defmodule ArkEcosystem.Client.API.Two.TransactionsTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/transactions/dummyId"} ->
-        json(%{"success" => true, "data" => %{ "id": "dummyId" }})
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/transactions"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/transactions/unconfirmed/dummyUnconfirmedId"} ->
-        json(%{"success" => true, "data" => %{ "id": "dummyUnconfirmedId" }})
+        json(%{"success" => true, "data" => %{ id: "dummyUnconfirmedId" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/transactions/unconfirmed"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyUnconfirmedId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyUnconfirmedId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/transactions/types"} ->
-        json(%{"success" => true, "data" => %{ "TRANSFER": 0 }})
+        json(%{"success" => true, "data" => %{ TRANSFER: 0 }})
       %{method: :post, url: "http://127.0.0.1:4003/api/transactions"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyCreatedId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyCreatedId" }]})
       %{method: :post, url: "http://127.0.0.1:4003/api/transactions/search"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummySearch" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/votes_test.exs
+++ b/test/arkecosystem/client/two/votes_test.exs
@@ -12,9 +12,9 @@ defmodule ArkEcosystem.Client.API.Two.VotesTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/votes/dummyId"} ->
-        json(%{"success" => true, "data" => %{ "id": "dummyId" }})
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/votes"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
     end
     :ok
   end

--- a/test/arkecosystem/client/two/wallets_test.exs
+++ b/test/arkecosystem/client/two/wallets_test.exs
@@ -12,21 +12,21 @@ defmodule ArkEcosystem.Client.API.Two.WalletsTest do
   setup do
     mock fn
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId"} ->
-        json(%{"success" => true, "data" => %{ "id": "dummyId" }})
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/top"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyTopId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyTopId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/transactions"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyTransactionId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyTransactionId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/transactions/sent"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummySentTransactionId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummySentTransactionId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/transactions/received"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyReceivedTransactionId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyReceivedTransactionId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/votes"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummyVoteId" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummyVoteId" }]})
       %{method: :post, url: "http://127.0.0.1:4003/api/wallets/search"} ->
-        json(%{"success" => true, "data" => [%{ "id": "dummySearch" }]})
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
     end
     :ok
   end


### PR DESCRIPTION
## Proposed changes
Fixed the tests to remove the warning while running in. Nothing critical, but it remove a lot of useless output. The warnings were caused by the double quotes like here : 

`
json(%{"success" => true, "data" => %{ "synced": true }})
`

Which threw these warnings :

`
but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
`
## Types of changes

- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes