### PR TITLE
feat: 2.6 api endpoints

### DIFF
--- a/lib/arkecosystem/client/api/bridgechains.ex
+++ b/lib/arkecosystem/client/api/bridgechains.ex
@@ -1,0 +1,22 @@
+defmodule ArkEcosystem.Client.API.Bridgechains do
+  @moduledoc """
+  Documentation for ArkEcosystem.Client.API.Bridgechains
+  """
+
+  import ArkEcosystem.Client
+
+  @spec list(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def list(client, parameters \\ []) do
+    client |> get("bridgechains", parameters)
+  end
+
+  @spec show(Tesla.Client.t(), String.t()) :: ArkEcosystem.Client.response()
+  def show(client, id) do
+    client |> get("bridgechains/#{id}")
+  end
+
+  @spec search(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def search(client, parameters) do
+    client |> post("bridgechains/search", parameters)
+  end
+end

--- a/lib/arkecosystem/client/api/businesses.ex
+++ b/lib/arkecosystem/client/api/businesses.ex
@@ -1,0 +1,27 @@
+defmodule ArkEcosystem.Client.API.Businesses do
+  @moduledoc """
+  Documentation for ArkEcosystem.Client.API.Businesses
+  """
+
+  import ArkEcosystem.Client
+
+  @spec list(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def list(client, parameters \\ []) do
+    client |> get("businesses", parameters)
+  end
+
+  @spec show(Tesla.Client.t(), String.t()) :: ArkEcosystem.Client.response()
+  def show(client, id) do
+    client |> get("businesses/#{id}")
+  end
+
+  @spec bridgechains(Tesla.Client.t(), String.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def bridgechains(client, id, parameters \\ []) do
+    client |> get("businesses/#{id}/bridgechains", parameters)
+  end
+
+  @spec search(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def search(client, parameters) do
+    client |> post("businesses/search", parameters)
+  end
+end

--- a/lib/arkecosystem/client/api/locks.ex
+++ b/lib/arkecosystem/client/api/locks.ex
@@ -1,0 +1,27 @@
+defmodule ArkEcosystem.Client.API.Locks do
+  @moduledoc """
+  Documentation for ArkEcosystem.Client.API.Locks
+  """
+
+  import ArkEcosystem.Client
+
+  @spec list(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def list(client, parameters \\ []) do
+    client |> get("locks", parameters)
+  end
+
+  @spec show(Tesla.Client.t(), String.t()) :: ArkEcosystem.Client.response()
+  def show(client, id) do
+    client |> get("locks/#{id}")
+  end
+
+  @spec search(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def search(client, parameters) do
+    client |> post("locks/search", parameters)
+  end
+
+  @spec search(Tesla.Client.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def search(client, parameters) do
+    client |> post("unlocked/search", parameters)
+  end
+end

--- a/lib/arkecosystem/client/api/wallets.ex
+++ b/lib/arkecosystem/client/api/wallets.ex
@@ -20,6 +20,11 @@ defmodule ArkEcosystem.Client.API.Wallets do
     client |> get("wallets/#{id}")
   end
 
+  @spec locks(Tesla.Client.t(), String.t(), Keyword.t()) :: ArkEcosystem.Client.response()
+  def locks(client, id, parameters \\ []) do
+    client |> get("wallets/#{id}/locks", parameters)
+  end
+
   @spec transactions(Tesla.Client.t(), String.t(), Keyword.t()) :: ArkEcosystem.Client.response()
   def transactions(client, id, parameters \\ []) do
     client |> get("wallets/#{id}/transactions", parameters)

--- a/test/arkecosystem/client/bridgechains_test.exs
+++ b/test/arkecosystem/client/bridgechains_test.exs
@@ -1,0 +1,42 @@
+defmodule ArkEcosystem.Client.API.BridgechainsTest do
+  use ExUnit.Case
+  import ArkEcosystem.Client.API.Bridgechains
+  import Tesla.Mock
+
+  @client ArkEcosystem.Client.new(%{
+            host: "http://127.0.0.1:4003/api",
+            nethash: "578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23",
+            version: "1.1.1"
+          })
+
+  setup do
+    mock fn
+      %{method: :get, url: "http://127.0.0.1:4003/api/bridgechains/dummyId"} ->
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
+      %{method: :get, url: "http://127.0.0.1:4003/api/bridgechains"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
+      %{method: :post, url: "http://127.0.0.1:4003/api/bridgechains/search"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
+    end
+    :ok
+  end
+
+  test "call ArkEcosystem.Client.API.Bridgechains.list" do
+    assert {:ok, response} = list(@client)
+    assert Enum.at(response["data"],0)["id"] == "dummyId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Bridgechains.show" do
+    assert {:ok, response} = show(@client, "dummyId")
+    assert response["data"]["id"] == "dummyId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Bridgechains.search" do
+    assert {:ok, response} = search(@client, %{q: "searchQuery"})
+    assert Enum.at(response["data"], 0)["id"] == "dummySearch"
+    assert response["success"] == true
+  end
+
+end

--- a/test/arkecosystem/client/businesses_test.exs
+++ b/test/arkecosystem/client/businesses_test.exs
@@ -1,0 +1,50 @@
+defmodule ArkEcosystem.Client.API.BusinessesTest do
+  use ExUnit.Case
+  import ArkEcosystem.Client.API.Businesses
+  import Tesla.Mock
+
+  @client ArkEcosystem.Client.new(%{
+            host: "http://127.0.0.1:4003/api",
+            nethash: "578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23",
+            version: "1.1.1"
+          })
+
+  setup do
+    mock fn
+      %{method: :get, url: "http://127.0.0.1:4003/api/businesses/dummyId"} ->
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
+      %{method: :get, url: "http://127.0.0.1:4003/api/businesses"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
+      %{method: :get, url: "http://127.0.0.1:4003/api/businesses/dummyId/bridgechains"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummyBridgechainId" }]})
+      %{method: :post, url: "http://127.0.0.1:4003/api/businesses/search"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
+    end
+    :ok
+  end
+
+  test "call ArkEcosystem.Client.API.Businesses.list" do
+    assert {:ok, response} = list(@client)
+    assert Enum.at(response["data"],0)["id"] == "dummyId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Businesses.show" do
+    assert {:ok, response} = show(@client, "dummyId")
+    assert response["data"]["id"] == "dummyId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Businesses.bridgechains" do
+    assert {:ok, response} = bridgechains(@client, "dummyId")
+    assert Enum.at(response["data"], 0)["id"] == "dummyBridgechainId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Businesses.search" do
+    assert {:ok, response} = search(@client, %{q: "searchQuery"})
+    assert Enum.at(response["data"], 0)["id"] == "dummySearch"
+    assert response["success"] == true
+  end
+
+end

--- a/test/arkecosystem/client/locks_test.exs
+++ b/test/arkecosystem/client/locks_test.exs
@@ -1,0 +1,50 @@
+defmodule ArkEcosystem.Client.API.LocksTest do
+  use ExUnit.Case
+  import ArkEcosystem.Client.API.Locks
+  import Tesla.Mock
+
+  @client ArkEcosystem.Client.new(%{
+            host: "http://127.0.0.1:4003/api",
+            nethash: "578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23",
+            version: "1.1.1"
+          })
+
+  setup do
+    mock fn
+      %{method: :get, url: "http://127.0.0.1:4003/api/locks/dummyId"} ->
+        json(%{"success" => true, "data" => %{ id: "dummyId" }})
+      %{method: :get, url: "http://127.0.0.1:4003/api/locks"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
+      %{method: :post, url: "http://127.0.0.1:4003/api/locks/search"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
+      %{method: :post, url: "http://127.0.0.1:4003/api/locks/unlocked"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummySearch" }]})
+    end
+    :ok
+  end
+
+  test "call ArkEcosystem.Client.API.Locks.list" do
+    assert {:ok, response} = list(@client)
+    assert Enum.at(response["data"],0)["id"] == "dummyId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Locks.show" do
+    assert {:ok, response} = show(@client, "dummyId")
+    assert response["data"]["id"] == "dummyId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Locks.search" do
+    assert {:ok, response} = search(@client, %{q: "searchQuery"})
+    assert Enum.at(response["data"], 0)["id"] == "dummySearch"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Locks.unlocked" do
+    assert {:ok, response} = unlocked(@client, %{q: "searchQuery"})
+    assert Enum.at(response["data"], 0)["id"] == "dummySearch"
+    assert response["success"] == true
+  end
+
+end

--- a/test/arkecosystem/client/wallets_test.exs
+++ b/test/arkecosystem/client/wallets_test.exs
@@ -17,6 +17,8 @@ defmodule ArkEcosystem.Client.API.WalletsTest do
         json(%{"success" => true, "data" => [%{ id: "dummyId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/top"} ->
         json(%{"success" => true, "data" => [%{ id: "dummyTopId" }]})
+      %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/locks"} ->
+        json(%{"success" => true, "data" => [%{ id: "dummyLockId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/transactions"} ->
         json(%{"success" => true, "data" => [%{ id: "dummyTransactionId" }]})
       %{method: :get, url: "http://127.0.0.1:4003/api/wallets/dummyId/transactions/sent"} ->
@@ -46,6 +48,12 @@ defmodule ArkEcosystem.Client.API.WalletsTest do
   test "call ArkEcosystem.Client.API.Wallets.top" do
     assert {:ok, response} = top(@client)
     assert Enum.at(response["data"],0)["id"] == "dummyTopId"
+    assert response["success"] == true
+  end
+
+  test "call ArkEcosystem.Client.API.Wallets.locks" do
+    assert {:ok, response} = locks(@client, "dummyId")
+    assert Enum.at(response["data"],0)["id"] == "dummyLockId"
     assert response["success"] == true
   end
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

Adds the following API endpoints

**GET**

- [x] `bridgechains`
- [x] `bridgechains/{id}`
- [x] `businesses`
- [x] `businesses/{id}`
- [x] `businesses/{id}/bridgechains`
- [x] `wallets/{id}/locks`
- [x] `locks`
- [x] `locks/{id}`

**POST**

- [x] `businesses/search`
- [x] `bridgechains/search`
- [x] `locks/search`
- [x] `locks/unlocked`

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
